### PR TITLE
Refactor of cache flush steps into a separate script.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,16 +141,15 @@ runs:
       if: ${{ inputs.flush-cache != 'true' }}
       uses: saucal/action-inssheption@v2
       with:
-        GH_TOKEN:                       ${{ inputs.git-token }}
-        TARGET_SSH_HOST:                ${{ inputs.env-host }}
-        TARGET_SSH_USER:                ${{ inputs.env-user }}
-        TARGET_SSH_KEY:                 ${{ inputs.env-key }}
-        TARGET_SSH_PASS:                ${{ inputs.env-pass }}
-        TARGET_SSH_PORT:                ${{ inputs.env-port }}
-        TARGET_SSH_PATH_DIR:            ${{ inputs.env-remote-root }}
-        INPUT_FLUSH_CACHE:              ${{ inputs.flush-cache }}
-        INPUT_FLUSH_CACHE_EXTRA_PARAMS: ${{ inputs.flush-cache-extra-params }}
-        INSSHEPTION_SCRIPT:             ${{ github.action_path }}/flush-cache.sh
+        GH_TOKEN:            ${{ inputs.git-token }}
+        TARGET_SSH_HOST:     ${{ inputs.env-host }}
+        TARGET_SSH_USER:     ${{ inputs.env-user }}
+        TARGET_SSH_KEY:      ${{ inputs.env-key }}
+        TARGET_SSH_PASS:     ${{ inputs.env-pass }}
+        TARGET_SSH_PORT:     ${{ inputs.env-port }}
+        TARGET_SSH_PATH_DIR: ${{ inputs.env-remote-root }}
+        INSSHEPTION_SCRIPT:  ${{ github.action_path }}/flush-cache.sh
+        EXTRA_SCRIPT_ARGS:   "--flush-cache ${{ inputs.flush-cache }} --flush-cache-extra-params ${{ inputs.flush-cache-extra-params }}"
 
     - name: Send details about SSH consistency
       if: ${{ always() && ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'false' ) && steps.deploy-to-ssh.outcome == 'failure' }}

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
 
     - name: Deploy to SSH
       id: 'deploy-to-ssh'
-      uses: saucal/action-deploy-ssh@feature/force-delete # TODO: Change to v4 post launch
+      uses: saucal/action-deploy-ssh@v4
       with:
         manifest: "${{ ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'true' ) && steps.build-to-git.outputs.manifest || '' }}"
         env-host: ${{ inputs.env-host }}

--- a/action.yml
+++ b/action.yml
@@ -137,105 +137,20 @@ runs:
         ssh-handle-perms: ${{ inputs.ssh-handle-perms }}
         consistency-check: ${{ ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'false' ) && 'true' || '' }}
 
-    - name: Prepare flush cache
-      id: 'flush-cache-prepare'
-      shell: bash
-      run: |
-        INPUT_FLUSH_CACHE="${{ inputs.flush-cache }}"
-        if [ "${INPUT_FLUSH_CACHE}" != 'false' ]; then
-          echo "do-flush=true" >> $GITHUB_OUTPUT
-          if [ "${INPUT_FLUSH_CACHE}" == 'true' ]; then
-            echo "flush-type=default" >> $GITHUB_OUTPUT
-          elif [ "${INPUT_FLUSH_CACHE}" == 'auto' ]; then
-            # maybe attempt to detect flush type
-            # would need insshetion to run some commands through ssh maybe
-            # turn into default for the time being, so it doesn't do anything
-            echo "flush-type=default" >> $GITHUB_OUTPUT
-          else
-            echo "flush-type=${INPUT_FLUSH_CACHE}" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "do-flush=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Flush cache
-      if: ${{ steps.flush-cache-prepare.outputs.do-flush == 'true' }}
-      id: 'flush-cache'
-      working-directory: ${{ github.workspace }}/${{ inputs.built }}
-      shell: bash {0}
-      run: |
-        INPUT_FLUSH_CACHE="${{ steps.flush-cache-prepare.outputs.do-flush }}"
-        INPUT_FLUSH_CACHE_TYPE="${{ steps.flush-cache-prepare.outputs.flush-type }}"
-        INPUT_FLUSH_CACHE_EXTRA_PARAMS="${{ inputs.flush-cache-extra-params }}"
-        echo "::group::Flushing cache with type: ${INPUT_FLUSH_CACHE_TYPE}"
-
-        exitcode=0
-        if [ "${INPUT_FLUSH_CACHE_TYPE}" == 'convesio' ]; then
-          echo "Running command: " curl -s -f -I -X POST "${INPUT_FLUSH_CACHE_EXTRA_PARAMS}"
-          echo ""
-          curl -s -f -I -X POST "${INPUT_FLUSH_CACHE_EXTRA_PARAMS}" || exitcode=$?
-        else
-          echo "By default, we're not flushing cache, as we don't know how to do it in a generic way"
-        fi
-        echo "::endgroup::"
-        if [ $exitcode -ne 0 ]; then
-          echo ""
-          echo "::warning title:Flush cache failed::Failed to flush cache"
-        else
-          echo "Flushed cache"
-        fi
-
-    - name: Kinsta cache flush # https://kinsta.com/docs/wordpress-hosting/site-management/wordpress-wp-cli/#clear-the-full-page-cache-and-edge-cache
-      if: ${{ steps.flush-cache-prepare.outputs.do-flush == 'true' && contains( steps.flush-cache-prepare.outputs.flush-type, 'kinsta' ) }}
+      if: ${{ inputs.flush-cache != 'true' }}
       uses: saucal/action-inssheption@v2
       with:
-        GH_TOKEN:            ${{ inputs.git-token }}
-        TARGET_SSH_HOST:     ${{ inputs.env-host }}
-        TARGET_SSH_USER:     ${{ inputs.env-user }}
-        TARGET_SSH_KEY:      ${{ inputs.env-key }}
-        TARGET_SSH_PASS:     ${{ inputs.env-pass }}
-        TARGET_SSH_PORT:     ${{ inputs.env-port }}
-        TARGET_SSH_PATH_DIR: ${{ inputs.env-remote-root }}
-        EXTRA_SCRIPT_ARGS:   -c "notice 'Flushing Kinsta cache'" -c "rcli kinsta cache purge"
-
-    - name: WPE cache flush
-      if: ${{ steps.flush-cache-prepare.outputs.do-flush == 'true' && contains( steps.flush-cache-prepare.outputs.flush-type, 'wpe' ) }}
-      uses: saucal/action-inssheption@v2
-      with:
-        GH_TOKEN:            ${{ inputs.git-token }}
-        TARGET_SSH_HOST:     ${{ inputs.env-host }}
-        TARGET_SSH_USER:     ${{ inputs.env-user }}
-        TARGET_SSH_KEY:      ${{ inputs.env-key }}
-        TARGET_SSH_PASS:     ${{ inputs.env-pass }}
-        TARGET_SSH_PORT:     ${{ inputs.env-port }}
-        TARGET_SSH_PATH_DIR: ${{ inputs.env-remote-root }}
-        EXTRA_SCRIPT_ARGS:   -c "notice 'Flushing WPE cache'" -c "rcli cdn-cache flush"
-    
-    - name: Object Cache flush
-      if: ${{ steps.flush-cache-prepare.outputs.do-flush == 'true' && contains( steps.flush-cache-prepare.outputs.flush-type, 'objectcache' ) }}
-      uses: saucal/action-inssheption@v2
-      with:
-        GH_TOKEN:            ${{ inputs.git-token }}
-        TARGET_SSH_HOST:     ${{ inputs.env-host }}
-        TARGET_SSH_USER:     ${{ inputs.env-user }}
-        TARGET_SSH_KEY:      ${{ inputs.env-key }}
-        TARGET_SSH_PASS:     ${{ inputs.env-pass }}
-        TARGET_SSH_PORT:     ${{ inputs.env-port }}
-        TARGET_SSH_PATH_DIR: ${{ inputs.env-remote-root }}
-        EXTRA_SCRIPT_ARGS:   -c "notice 'Flushing object cache'" -c "rcli cache flush"
-
-    - name: WP Rocket Cache flush # requires wp-rocket cli package https://docs.wp-rocket.me/article/1497-wp-cli-interface-for-wp-rocket
-      if: ${{ steps.flush-cache-prepare.outputs.do-flush == 'true' && contains( steps.flush-cache-prepare.outputs.flush-type, 'wprocket' ) }}
-      uses: saucal/action-inssheption@v2
-      with:
-        GH_TOKEN:            ${{ inputs.git-token }}
-        TARGET_SSH_HOST:     ${{ inputs.env-host }}
-        TARGET_SSH_USER:     ${{ inputs.env-user }}
-        TARGET_SSH_KEY:      ${{ inputs.env-key }}
-        TARGET_SSH_PASS:     ${{ inputs.env-pass }}
-        TARGET_SSH_PORT:     ${{ inputs.env-port }}
-        TARGET_SSH_PATH_DIR: ${{ inputs.env-remote-root }}
-        EXTRA_SCRIPT_ARGS:   -c "notice 'Flushing WP Rocket cache'" -c "rcli rocket clean --confirm"
+        GH_TOKEN:                       ${{ inputs.git-token }}
+        TARGET_SSH_HOST:                ${{ inputs.env-host }}
+        TARGET_SSH_USER:                ${{ inputs.env-user }}
+        TARGET_SSH_KEY:                 ${{ inputs.env-key }}
+        TARGET_SSH_PASS:                ${{ inputs.env-pass }}
+        TARGET_SSH_PORT:                ${{ inputs.env-port }}
+        TARGET_SSH_PATH_DIR:            ${{ inputs.env-remote-root }}
+        INPUT_FLUSH_CACHE:              ${{ inputs.flush-cache }}
+        INPUT_FLUSH_CACHE_EXTRA_PARAMS: ${{ inputs.flush-cache-extra-params }}
+        INSSHEPTION_SCRIPT:             ${{ github.action_path }}/flush-cache.sh
 
     - name: Send details about SSH consistency
       if: ${{ always() && ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'false' ) && steps.deploy-to-ssh.outcome == 'failure' }}

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ inputs:
   flush-cache:
     description: "Flush cache after deployment"
     required: false
-    default: 'false'
+    default: 'auto'
 
   flush-cache-extra-params:
     description: "Flush cache parameters. This is depending on the flush-cache setup."

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
 
     - name: Deploy to SSH
       id: 'deploy-to-ssh'
-      uses: saucal/action-deploy-ssh@v4
+      uses: saucal/action-deploy-ssh@feature/force-delete # TODO: Change to v4 post launch
       with:
         manifest: "${{ ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'true' ) && steps.build-to-git.outputs.manifest || '' }}"
         env-host: ${{ inputs.env-host }}

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
         consistency-check: ${{ ( inputs.disable-consistency-check != 'true' && steps.build-to-git.outputs.has-prev-commit == 'false' ) && 'true' || '' }}
 
     - name: Flush cache
-      if: ${{ inputs.flush-cache != 'true' }}
+      if: ${{ inputs.flush-cache != 'false' }}
       uses: saucal/action-inssheption@v2
       with:
         GH_TOKEN:            ${{ inputs.git-token }}

--- a/flush-cache.sh
+++ b/flush-cache.sh
@@ -25,11 +25,15 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
+if [ "${INPUT_FLUSH_CACHE}" == 'false' ]; then
+    echo "Skipping cache flush" # We shouldn't be here if its false, but just in case.
+    exit 0
+fi
+
 echo "::group::Flushing cache"
 
-if [ "${INPUT_FLUSH_CACHE}" == 'auto' ] || [ "${INPUT_FLUSH_CACHE}" == 'default' ]; then
-    echo ::warning title=Flush cache::No Generic way to flush cache. Exiting.
-    exit 0;
+if [ "${INPUT_FLUSH_CACHE}" == 'default' ]; then
+    INPUT_FLUSH_CACHE="auto"
 fi
 
 exitcode=0
@@ -39,24 +43,29 @@ if [[ "${INPUT_FLUSH_CACHE}" == *"convesio"* ]]; then
     curl -s -f -I -X POST "${INPUT_FLUSH_CACHE_EXTRA_PARAMS}" || exitcode=$?
 fi
 
-if [[ "${INPUT_FLUSH_CACHE}" == *"kinsta"* ]]; then
+if [[ "${INPUT_FLUSH_CACHE}" == *"kinsta"* ]] || ([[ "${INPUT_FLUSH_CACHE}" == "auto" ]] && rcli cli has-command "kinsta cache purge"); then
     notice 'Flushing Kinsta cache'
     rcli kinsta cache purge || exitcode=$?
 fi
 
-if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]]; then
+if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]] || ([[ "${INPUT_FLUSH_CACHE}" == "auto" ]] && rcli cli has-command "cdn-cache flush"); then
     notice 'Flushing WPE cache'
     rcli cdn-cache flush || exitcode=$?
 fi
 
-if [[ "${INPUT_FLUSH_CACHE}" == *"objectcache"* ]]; then
-    notice 'Flushing object cache'
-    rcli cache flush || exitcode=$?
+if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]] || ([[ "${INPUT_FLUSH_CACHE}" == "auto" ]] && rcli cli has-command "nexcess-mapps cache flush"); then
+    notice 'Flushing NEXCESS cache'
+    rcli nexcess-mapps cache flush --all || exitcode=$?
 fi
 
-if [[ "${INPUT_FLUSH_CACHE}" == *"wprocket"* ]]; then
+if [[ "${INPUT_FLUSH_CACHE}" == *"wprocket"* ]] || ([[ "${INPUT_FLUSH_CACHE}" == "auto" ]] && rcli cli has-command "rocket clean"); then
     notice 'Flushing WP Rocket cache'
     rcli rocket clean --confirm || exitcode=$?
+fi
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"objectcache"* ]] || [[ "${INPUT_FLUSH_CACHE}" == "auto" ]]; then
+    notice 'Flushing object cache'
+    rcli cache flush || exitcode=$?
 fi
 
 if [ $exitcode -ne 0 ]; then

--- a/flush-cache.sh
+++ b/flush-cache.sh
@@ -41,7 +41,7 @@ fi
 
 if [[ "${INPUT_FLUSH_CACHE}" == *"kinsta"* ]]; then
     notice 'Flushing Kinsta cache'
-    rcli kinstZ cache purge || exitcode=$?
+    rcli kinsta cache purge || exitcode=$?
 fi
 
 if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]]; then

--- a/flush-cache.sh
+++ b/flush-cache.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+echo "::group::Flushing cache"
+
+if [ "${INPUT_FLUSH_CACHE}" == 'auto' ] || [ "${INPUT_FLUSH_CACHE}" == 'default' ]; then
+    echo ::warning title=Flush cache::No Generic way to flush cache. Exiting.
+    exit 0;
+fi
+
+exitcode=0
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"convesio"* ]]; then
+    notice "Running command: " curl -s -f -I -X POST "${INPUT_FLUSH_CACHE_EXTRA_PARAMS}"
+    curl -s -f -I -X POST "${INPUT_FLUSH_CACHE_EXTRA_PARAMS}" || exitcode=$?
+fi
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"kinsta"* ]]; then
+    notice 'Flushing Kinsta cache'
+    rcli kinsta cache purge || exitcode=$?
+fi
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]]; then
+    notice 'Flushing WPE cache'
+    rcli cdn-cache flush || exitcode=$?
+fi
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"objectcache"* ]]; then
+    notice 'Flushing object cache'
+    rcli cache flush || exitcode=$?
+fi
+
+if [[ "${INPUT_FLUSH_CACHE}" == *"wprocket"* ]]; then
+    notice 'Flushing WP Rocket cache'
+    rcli rocket clean --confirm || exitcode=$?
+fi
+
+if [ $exitcode -ne 0 ]; then
+    echo ""
+    echo "::warning title:Flush cache failed::Failed to flush cache"
+else
+    echo "Flushed cache"
+fi
+
+echo "::endgroup::"
+
+exit 0 # Prevent the script from failing the workflow.

--- a/flush-cache.sh
+++ b/flush-cache.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+POSITIONAL_ARGS=()
+INPUT_FLUSH_CACHE=""
+INPUT_FLUSH_CACHE_EXTRA_PARAMS=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --flush-cache)
+            INPUT_FLUSH_CACHE="$2"
+            shift # past argument
+            shift # past argument
+            ;;
+        --flush-cache-extra-params)
+            INPUT_FLUSH_CACHE_EXTRA_PARAMS="$2"
+            shift # past argument
+            shift # past argument
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1") # save positional arg
+            shift # past argument
+            ;;
+    esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
 echo "::group::Flushing cache"
 
 if [ "${INPUT_FLUSH_CACHE}" == 'auto' ] || [ "${INPUT_FLUSH_CACHE}" == 'default' ]; then

--- a/flush-cache.sh
+++ b/flush-cache.sh
@@ -41,7 +41,7 @@ fi
 
 if [[ "${INPUT_FLUSH_CACHE}" == *"kinsta"* ]]; then
     notice 'Flushing Kinsta cache'
-    rcli kinsta cache purge || exitcode=$?
+    rcli kinstZ cache purge || exitcode=$?
 fi
 
 if [[ "${INPUT_FLUSH_CACHE}" == *"wpe"* ]]; then


### PR DESCRIPTION
If the flush command fails the action - which happens after deployment succeeded, what happens is that we do deploy, but we don't push a commit to the built repo, so the repo & server go out of sync.

The logic changed here so that a failure in the cache flush command will not stop the workflow - only show a warning in the workflow.


Related to [Kinsta cache failure causing step failure](https://app.clickup.com/t/86dvgzmwd)