### PR TITLE
Allows specifying a different local root directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Env Password"
     required: false
     default: ''
+  env-local-root:
+    description: "Env Local Root (relative to the built directory)"
+    required: false
+    default: ''
   env-remote-root:
     description: "Env Remote Root"
     required: true
@@ -127,7 +131,7 @@ runs:
         env-user: ${{ inputs.env-user }}
         env-key: ${{ inputs.env-key }}
         env-pass: ${{ inputs.env-pass }}
-        env-local-root: ${{ inputs.built }}
+        env-local-root: ${{ inputs.built }}/${{ inputs.env-local-root }}
         env-remote-root: ${{ inputs.env-remote-root }}
         force-ignore: ${{ inputs.ssh-ignore }}
         force-ignore-extra: ${{ inputs.ssh-ignore-extra }}


### PR DESCRIPTION
Enables users to specify a local root directory different from the built repository root.

This adds an `env-local-root` input to the action, allowing users to define a subdirectory within the built directory to be used as the local root for deployment.

This provides more flexibility in scenarios where the deployment target is not the entire built repository.