### PR TITLE
Fix: empty artifact name prefix on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -157,6 +157,7 @@ runs:
 
     - name: Compute artifact name prefix
       id: artifact-meta
+      if: ${{ always() }}
       shell: bash
       env:
         FULL_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Bug
Uploaded artifacts were named `-deploy-rsync-plan` / `-consistency-diffs` (empty prefix).

## Cause
Artifacts are only produced when the consistency check **fails** (`action-deploy-ssh` calls `process.exit(1)`). In a composite action, a step with no `if:` is **skipped** once a prior step fails — so `Compute artifact name prefix` was skipped, leaving `steps.artifact-meta.outputs.prefix` empty. The upload steps still ran (`if: always()`), producing the empty-prefix names.

## Fix
Add `if: ${{ always() }}` to the prefix step so it runs on the failure path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)